### PR TITLE
Update Dockerfile to use latest version of ember watson

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 RUN apk --update add nodejs git ruby ruby-dev build-base && \
   apk del build-base && rm -fr /usr/share/ri
 
-RUN npm install -g mrb/ember-watson.git#95387b7
+RUN npm install -g ember-watson@latest
 
 COPY . /usr/src/app
 


### PR DESCRIPTION
Uses the main fork of ember watson and uses the latest version. I can't find `95387b7` so I'm not sure how old the current version is, but the last commit was on [June 22](https://github.com/q-centrix/codeclimate-watson/commit/299f50c69ca75f078a0c76bb186c2fa8f446d67e#diff-3254677a7917c6c01f55212f86c57fbf). The `mrb` fork appears to be 8 commits behind the main fork and has no other differences.
