### PR TITLE
Exit engine with same code as the ember-watson process

### DIFF
--- a/bin/codeclimate-watson
+++ b/bin/codeclimate-watson
@@ -18,3 +18,4 @@ end
 cmd << " -d all '.'"
 result = `#{cmd}`
 print result
+exit $?.exitstatus

--- a/circle.yml
+++ b/circle.yml
@@ -22,4 +22,6 @@ deployment:
     commands:
       - docker push $registry_root/$image_name:b$CIRCLE_BUILD_NUM
 
-
+notify:
+  webhooks:
+    - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ machine:
     image_name: codeclimate-watson
 
 dependencies:
-  pre:
+  override:
     - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
     - curl https://sdk.cloud.google.com | bash
     - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json

--- a/circle.yml
+++ b/circle.yml
@@ -7,20 +7,30 @@ machine:
 
 dependencies:
   override:
-    - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
-    - curl https://sdk.cloud.google.com | bash
-    - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
-    - gcloud docker -a
+    - >
+      docker run
+      --env CIRCLE_BRANCH
+      --env CIRCLE_PROJECT_REPONAME
+      --env CIRCLE_TOKEN
+      --env GCR_JSON_KEY
+      --volume /var/run/docker.sock:/var/run/docker.sock
+      codeclimate/patrick pull || true
 
 test:
   override:
-    - docker build -t=$registry_root/$image_name:b$CIRCLE_BUILD_NUM .
+    - docker build -t=codeclimate/$image_name:b$CIRCLE_BUILD_NUM .
 
 deployment:
   registry:
     branch: master
     commands:
-      - docker push $registry_root/$image_name:b$CIRCLE_BUILD_NUM
+      - >
+        docker run
+        --env CIRCLE_BUILD_NUM
+        --env CIRCLE_PROJECT_REPONAME
+        --env GCR_JSON_KEY
+        --volume /var/run/docker.sock:/var/run/docker.sock
+        codeclimate/patrick push gcr
 
 notify:
   webhooks:


### PR DESCRIPTION
Kind of an important bug fix: if watson was crashing, we were not bubbling
that up properly, so the engine would still appear as "passed".

Also fire webhooks for shipbot.

cc @codeclimate/review
